### PR TITLE
(1-2)入力値エラー処理機能の実装

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -3,11 +3,13 @@ package com.example.controller;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.validation.BindingResult;
 
 import com.example.domain.Administrator;
 import com.example.form.InsertAdministratorForm;
@@ -72,7 +74,11 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@PostMapping("/insert")
-	public String insert(InsertAdministratorForm form) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
+		if(result.hasErrors()) {
+			return toInsert();
+		}
+		
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -1,5 +1,9 @@
 package com.example.form;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Email;
+import org.hibernate.validator.constraints.Length;
+
 /**
  * 管理者情報登録時に使用するフォーム.
  * 
@@ -8,10 +12,16 @@ package com.example.form;
  */
 public class InsertAdministratorForm {
 	/** 名前 */
+	@NotBlank(message="名前を入力してください")
+	@Length(max=255, message="255文字以下で入力してください")
 	private String name;
 	/** メールアドレス */
+	@NotBlank(message="メールアドレスを入力してください")
+	@Email(message="正しいメールアドレスの形式で入力してください")
+	@Length(max=255, message="255文字以下で入力してください")
 	private String mailAddress;
 	/** パスワード */
+	@Length(min=6, max=16, message="6文字以上、16文字以下で入力してください")
 	private String password;
 
 	public String getName() {

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -100,30 +100,30 @@
                     </div>
                   </div>
                 </div>
-                <!-- パスワード -->
-                <div class="form-group">
-                  <div class="row">
-                    <div class="col-sm-12">
-                      <label for="password"> パスワード: </label>
-                      <label
-                        th:errors="*{password}"
-                        class="error-messages"
-                      >
-                        パスワードを入力してください
-                      </label>
-                      <input
-                        type="password"
-                        name="password"
-                        id="password"
-                        class="form-control"
-                        placeholder="password"
-                        th:field="*{password}"
-                        th:errorclass="error-input"
-                        value="xxxxxxxx"
-                      />
+                  <!-- パスワード -->
+                  <div class="form-group">
+                    <div class="row">
+                      <div class="col-sm-12">
+                        <label for="password"> パスワード: </label>
+                        <label
+                          th:errors="*{password}"
+                          class="error-messages"
+                        >
+                          パスワードを入力してください
+                        </label>
+                        <input
+                          type="password"
+                          name="password"
+                          id="password"
+                          class="form-control"
+                          placeholder="password"
+                          th:field="*{password}"
+                          th:errorclass="error-input"
+                          value="xxxxxxxx"
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
                 <!-- 登録ボタン -->
                 <div class="form-group">
                   <div class="row">


### PR DESCRIPTION
# 要約
- 管理者登録画面の入力値エラー処理機能を実装しました。
- 仕様については「その他の資料」に記載しています。

# 観点
- 必要なバリデーションの仕様について、口頭ですり合わせしていただいたときから若干の変更を行いました（以下）
　- passwordを@Lengthのみにし@Blankを使わないようにした
　- mailAddressに@Blankを追加した
- 上記の点含め、バリデーションが正しい書き方になっているかご確認いただきたいです。

# その他の資料
- name
    - 確認項目：非空白（@NotBlank）、255文字以下（@Length）
    - 出力内容：
        - @NotBlank：名前を入力してください
        - @Length：255文字以下で入力してください
- mailAddress 
    - 確認項目：非空白（@NotBlank）、メールの形式（@Email）、255文字以下（@Length）
    - 出力内容：
        - @NotBlank：メールアドレスを入力してください
        - @Email：メールアドレスの形式で入力してください
        - @Length：255文字以下で入力してください
- password 
    - 確認項目：非空白（@NotBlank）、6文字以上16文字以下（@Length）
        - @Length：6文字以上、16文字以下で入力してください