### PR TITLE
 (1-3)管理者登録画面のメールアドレスの重複チェックの機能の実装

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -3,11 +3,13 @@ package com.example.controller;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.validation.BindingResult;
 
 import com.example.domain.Administrator;
 import com.example.form.InsertAdministratorForm;
@@ -72,7 +74,11 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@PostMapping("/insert")
-	public String insert(InsertAdministratorForm form) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
+		if(result.hasErrors()) {
+			return toInsert();
+		}
+		
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -1,5 +1,9 @@
 package com.example.form;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Email;
+import org.hibernate.validator.constraints.Length;
+
 /**
  * 管理者情報登録時に使用するフォーム.
  * 
@@ -8,10 +12,16 @@ package com.example.form;
  */
 public class InsertAdministratorForm {
 	/** 名前 */
+	@NotBlank(message="名前を入力してください")
+	@Length(max=255, message="255文字以下で入力してください")
 	private String name;
 	/** メールアドレス */
+	@NotBlank(message="メールアドレスを入力してください")
+	@Email(message="正しいメールアドレスの形式で入力してください")
+	@Length(max=255, message="255文字以下で入力してください")
 	private String mailAddress;
 	/** パスワード */
+	@Length(min=6, max=16, message="6文字以上、16文字以下で入力してください")
 	private String password;
 
 	public String getName() {

--- a/src/main/java/com/example/service/AdministratorService.java
+++ b/src/main/java/com/example/service/AdministratorService.java
@@ -3,6 +3,8 @@ package com.example.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 
 import com.example.domain.Administrator;
 import com.example.repository.AdministratorRepository;
@@ -28,7 +30,6 @@ public class AdministratorService {
 	public void insert(Administrator administrator) {
 		administratorRepository.insert(administrator);
 	}
-
 	/**
 	 * ログインをします.
 	 * 
@@ -39,5 +40,15 @@ public class AdministratorService {
 	public Administrator login(String mailAddress, String password) {
 		Administrator administrator = administratorRepository.findByMailAddressAndPassward(mailAddress, password);
 		return administrator;
+	}
+
+	/**
+	 * メールアドレスで管理者情報を検索する
+	 * 
+	 * @param mailAddress メールアドレス
+	 * @return 管理者情報 存在しない場合はnullが返ります
+	 */
+	public Administrator findByMailAddress(String mailAddress) {
+		return administratorRepository.findByMailAddress(mailAddress);
 	}
 }

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -100,30 +100,30 @@
                     </div>
                   </div>
                 </div>
-                <!-- パスワード -->
-                <div class="form-group">
-                  <div class="row">
-                    <div class="col-sm-12">
-                      <label for="password"> パスワード: </label>
-                      <label
-                        th:errors="*{password}"
-                        class="error-messages"
-                      >
-                        パスワードを入力してください
-                      </label>
-                      <input
-                        type="password"
-                        name="password"
-                        id="password"
-                        class="form-control"
-                        placeholder="password"
-                        th:field="*{password}"
-                        th:errorclass="error-input"
-                        value="xxxxxxxx"
-                      />
+                  <!-- パスワード -->
+                  <div class="form-group">
+                    <div class="row">
+                      <div class="col-sm-12">
+                        <label for="password"> パスワード: </label>
+                        <label
+                          th:errors="*{password}"
+                          class="error-messages"
+                        >
+                          パスワードを入力してください
+                        </label>
+                        <input
+                          type="password"
+                          name="password"
+                          id="password"
+                          class="form-control"
+                          placeholder="password"
+                          th:field="*{password}"
+                          th:errorclass="error-input"
+                          value="xxxxxxxx"
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
                 <!-- 登録ボタン -->
                 <div class="form-group">
                   <div class="row">


### PR DESCRIPTION
# 要点
-  管理者登録画面のメールアドレスの重複チェックの機能を実装しました
  - AdministratorServiceにfindByMailAddress()メソッドを追加しました。
  - AdministratorControllerのinsert()で、入力されたメールアドレスの管理者情報が存在しているかどうかの条件分岐の処理を追加しました。

# 観点
- Controllerでの処理が十分に簡潔に書かれているか、チェックいただきたいです。