### PR TITLE
(2-1)従業員一覧・詳細画面に、管理者の名前が表示されないバグの修正

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.ui.Model;
 
 import com.example.domain.Administrator;
 import com.example.form.InsertAdministratorForm;
@@ -73,16 +75,49 @@ public class AdministratorController {
 	 * @param form 管理者情報用フォーム
 	 * @return ログイン画面へリダイレクト
 	 */
+	
 	@PostMapping("/insert")
-	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult result, Model model) {		
+		// // エラーがあれば入力画面へ遷移
+		// if(result.hasErrors()) {
+		// 	return toInsert();
+		// }
+
+		// Administrator administrator = new Administrator();
+		// BeanUtils.copyProperties(form, administrator);
+
+		// // 登録されていないメールアドレスなら管理者を追加する
+		// if(administratorService.findByMailAddress(form.getMailAddress()) == null) {
+		// 	administratorService.insert(administrator);
+		// } else {
+		// 	// 登録されているメールアドレスなら登録画面へ遷移
+		// 	FieldError fieldError = new FieldError(result.getObjectName(), "mailAddress", "既に使用されているメールアドレスです");
+		// 	result.addError(fieldError);
+		// 	return toInsert();
+		// }
+
+		// // エラーがあれば入力画面へ遷移
+		// if(result.hasErrors()) {
+		// 	return toInsert();
+		// }
+
+		Administrator administrator = new Administrator();
+		BeanUtils.copyProperties(form, administrator);
+
+		// メールアドレスが既に登録されているならば、エラーメッセージを格納
+		if(administratorService.findByMailAddress(form.getMailAddress()) != null) {
+			FieldError fieldError = new FieldError(result.getObjectName(), "mailAddress", "既に使用されているメールアドレスです");
+			result.addError(fieldError);
+			// requesuスコープにフォームを格納し、入力値チェックがエラーの場合も入力欄にメールアドレスを残す
+			model.addAttribute(form);
+		}
+		// エラーが存在するならば、入力画面へ遷移
 		if(result.hasErrors()) {
 			return toInsert();
 		}
-		
-		Administrator administrator = new Administrator();
-		// フォームからドメインにプロパティ値をコピー
-		BeanUtils.copyProperties(form, administrator);
+		// 管理者情報をDBに追加
 		administratorService.insert(administrator);
+		
 		return "redirect:/";
 	}
 

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -125,6 +125,7 @@ public class AdministratorController {
 			redirectAttributes.addFlashAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 			return "redirect:/";
 		}
+		session.setAttribute("administrator", administrator);
 		return "redirect:/employee/showList";
 	}
 

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -78,33 +78,11 @@ public class AdministratorController {
 	
 	@PostMapping("/insert")
 	public String insert(@Validated InsertAdministratorForm form, BindingResult result, Model model) {		
-		// // エラーがあれば入力画面へ遷移
-		// if(result.hasErrors()) {
-		// 	return toInsert();
-		// }
-
-		// Administrator administrator = new Administrator();
-		// BeanUtils.copyProperties(form, administrator);
-
-		// // 登録されていないメールアドレスなら管理者を追加する
-		// if(administratorService.findByMailAddress(form.getMailAddress()) == null) {
-		// 	administratorService.insert(administrator);
-		// } else {
-		// 	// 登録されているメールアドレスなら登録画面へ遷移
-		// 	FieldError fieldError = new FieldError(result.getObjectName(), "mailAddress", "既に使用されているメールアドレスです");
-		// 	result.addError(fieldError);
-		// 	return toInsert();
-		// }
-
-		// // エラーがあれば入力画面へ遷移
-		// if(result.hasErrors()) {
-		// 	return toInsert();
-		// }
 
 		Administrator administrator = new Administrator();
 		BeanUtils.copyProperties(form, administrator);
 
-		// メールアドレスが既に登録されているならば、エラーメッセージを格納
+		// 結果がnullでないならば、エラーメッセージを格納
 		if(administratorService.findByMailAddress(form.getMailAddress()) != null) {
 			FieldError fieldError = new FieldError(result.getObjectName(), "mailAddress", "既に使用されているメールアドレスです");
 			result.addError(fieldError);

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -1,6 +1,7 @@
 package com.example.form;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Email;
 import org.hibernate.validator.constraints.Length;
 
@@ -16,7 +17,7 @@ public class InsertAdministratorForm {
 	@Length(max=255, message="255文字以下で入力してください")
 	private String name;
 	/** メールアドレス */
-	@NotBlank(message="メールアドレスを入力してください")
+	@NotEmpty(message="メールアドレスを入力してください")
 	@Email(message="正しいメールアドレスの形式で入力してください")
 	@Length(max=255, message="255文字以下で入力してください")
 	private String mailAddress;

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -1,6 +1,7 @@
 package com.example.form;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import org.hibernate.validator.constraints.Length;
 
@@ -23,6 +24,22 @@ public class InsertAdministratorForm {
 	/** パスワード */
 	@Length(min=6, max=16, message="6文字以上、16文字以下で入力してください")
 	private String password;
+	/** 確認用パスワード */
+	@Length(min=6, max=16, message="6文字以上、16文字以下で入力してください")
+	private String passwordConfirmation;
+
+	/**
+	 * パスワードと確認用パスワードが同値かどうかを確認する。trueでなければエラーになる。
+	 * @return boolean 
+	 */
+	@AssertTrue(message = "パスワードと確認用パスワードが異なります")
+	public boolean isPasswordValid() {
+		if (password == null || password.isEmpty()) {
+			return true;
+		}
+		
+		return password.equals(passwordConfirmation);
+	}
 
 	public String getName() {
 		return name;

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -26,7 +26,6 @@ public class InsertAdministratorForm {
 	@Length(min=6, max=16, message="6文字以上、16文字以下で入力してください")
 	private String password;
 	/** 確認用パスワード */
-	@Length(min=6, max=16, message="6文字以上、16文字以下で入力してください")
 	private String passwordConfirmation;
 
 	/**
@@ -65,7 +64,7 @@ public class InsertAdministratorForm {
 	public void setPassword(String password) {
 		this.password = password;
 	}
-	
+
 	public String getPasswordConfirmation() {
 		return passwordConfirmation;
 	}

--- a/src/main/java/com/example/repository/AdministratorRepository.java
+++ b/src/main/java/com/example/repository/AdministratorRepository.java
@@ -58,10 +58,12 @@ public class AdministratorRepository {
 	 * @return 管理者情報 存在しない場合はnullを返します
 	 */
 	public Administrator findByMailAddressAndPassward(String mailAddress, String password) {
+				
 		String sql = "select id,name,mail_address,password from administrators where mail_address= '" + mailAddress
 				+ "' and password='" + password + "'";
 		SqlParameterSource param = new MapSqlParameterSource();
 		List<Administrator> administratorList = template.query(sql, param, ADMINISTRATOR_ROW_MAPPER);
+		
 		if (administratorList.size() == 0) {
 			return null;
 		}
@@ -86,6 +88,12 @@ public class AdministratorRepository {
 	 * @return 管理者情報 存在しない場合はnullを返します
 	 */
 	public Administrator findByMailAddress(String mailAddress) {
+		
+		// nullまたは空文字または空白文字ならnullを返す
+		// if (mailAddress == null || mailAddress.isEmpty() || mailAddress.isBlank()) {
+		// 	return null;
+		// }
+		
 		String sql = "select id,name,mail_address,password from administrators where mail_address=:mailAddress";
 		SqlParameterSource param = new MapSqlParameterSource().addValue("mailAddress", mailAddress);
 		List<Administrator> administratorList = template.query(sql, param, ADMINISTRATOR_ROW_MAPPER);

--- a/src/main/java/com/example/service/AdministratorService.java
+++ b/src/main/java/com/example/service/AdministratorService.java
@@ -40,4 +40,14 @@ public class AdministratorService {
 		Administrator administrator = administratorRepository.findByMailAddressAndPassward(mailAddress, password);
 		return administrator;
 	}
+
+	/**
+	 * メールアドレスで管理者情報を検索する
+	 * 
+	 * @param mailAddress メールアドレス
+	 * @return 管理者情報 存在しない場合はnullが返ります
+	 */
+	public Administrator findByMailAddress(String mailAddress) {
+		return administratorRepository.findByMailAddress(mailAddress);
+	}
 }

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -109,15 +109,38 @@
                           th:errors="*{password}"
                           class="error-messages"
                         >
-                          パスワードを入力してください
+                          6文字以上、16文字以下で入力してください
                         </label>
                         <input
                           type="password"
                           name="password"
                           id="password"
                           class="form-control"
-                          placeholder="password"
+                          placeholder="パスワード"
                           th:field="*{password}"
+                          th:errorclass="error-input"
+                          value="xxxxxxxx"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <div class="row">
+                      <div class="col-sm-12">
+                        <label for="passwordConfirmation"> 確認用パスワード: </label>
+                        <label
+                          th:errors="*{passwordConfirmation}"
+                          class="error-messages"
+                        >
+                          6文字以上、16文字以下で入力してください
+                        </label>
+                        <input
+                          type="password"
+                          name="passwordConfirmation"
+                          id="passwordConfirmation"
+                          class="form-control"
+                          placeholder="確認用パスワード"
+                          th:field="*{passwordConfirmation}"
                           th:errorclass="error-input"
                           value="xxxxxxxx"
                         />

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -67,7 +67,7 @@
               </li>
             </ul>
             <p class="navbar-text navbar-right">
-              <span th:text="${administratorName}">山田太郎</span
+              <span th:text="${session.administrator.name}">山田太郎</span
               >さんこんにちは！ &nbsp;&nbsp;&nbsp;
               <a
                 href="../administrator/login.html"

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -67,7 +67,7 @@
               </li>
             </ul>
             <p class="navbar-text navbar-right">
-              <span th:text="${administratorName}">山田太郎</span
+              <span th:text="${session.administrator.name}">山田太郎</span
               >さんこんにちは！ &nbsp;&nbsp;&nbsp;
               <a
                 href="../administrator/login.html"


### PR DESCRIPTION
# 要点 
- 従業員一覧画面と従業員詳細画面のナビゲ ーションに、ログインしている管理者の名前が表示されないバグの修正
- 値がsessionスコープに格納されていなかったので格納し、viewもそれに併せて書き換えました

# 観点
- なるべくrequestスコープで処理ができないかを考えましたが、ログイン後のページ遷移のたびにrequestスコープにドメインを渡すと煩雑になると考え、今回はsessionスコープで処理を行うことにしました。その判断についてご意見いただきたいです。